### PR TITLE
OS X 10.10.5 & clang; 16 of 2054 tests failing.

### DIFF
--- a/src/datum.h
+++ b/src/datum.h
@@ -63,6 +63,11 @@ public:
     Datum(Protocol::Term::TermType type) : Datum(static_cast<double>(type)) { }
     Datum(const char* string) : Datum(static_cast<std::string>(string)) { }
 
+#ifdef __APPLE__
+    Datum(unsigned long number_) : Datum(static_cast<double>(number_)) { }
+    Datum(long number_) : Datum(static_cast<double>(number_)) { }
+#endif
+
     // Cursors are implicitly converted into datums
     Datum(Cursor&&);
     Datum(const Cursor&);

--- a/src/error.h
+++ b/src/error.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef __APPLE__
+#include <errno.h>
+#endif
+
 #include <cstdarg>
 #include <cstring>
 #include <string>

--- a/src/json.cc
+++ b/src/json.cc
@@ -1,6 +1,12 @@
 
 #include <cstring>
+
 #include <locale.h>
+
+#ifdef __APPLE__
+#include <stdlib.h>
+#include <xlocale.h>
+#endif
 
 #include "json.h"
 #include "error.h"

--- a/src/net.cc
+++ b/src/net.cc
@@ -11,6 +11,16 @@
 #include "stream.h"
 #include "json.h"
 
+extern "C" {
+static inline void rdbxx_debug(uint64_t token_got, const char* msg) {
+#ifdef __APPLE__
+    fprintf(stderr, "[%llu] << %s\n", token_got, msg);
+#else
+    fprintf(stderr, "[%zu] << %s\n", token_got, msg);
+#endif
+}
+}
+
 namespace RethinkDB {
 
 const int debug_net = 0;
@@ -270,7 +280,7 @@ Response Connection::ReadLock::read_loop(uint64_t token_want, CacheLock&& guard)
         ResponseBuffer stream(this, length);
         Datum datum = read_datum(stream);
 
-        if (debug_net > 0) fprintf(stderr, "[%zu] << %s\n", token_got, write_datum(datum).c_str());
+        if (debug_net > 0) ::rdbxx_debug(token_got, write_datum(datum).c_str());
 
         Response response(std::move(datum));
 
@@ -316,7 +326,7 @@ Token Connection::start_query(const std::string& query) {
 }
 
 void Connection::WriteLock::send_query(uint64_t token, const std::string& query) {
-    if (debug_net > 0) fprintf(stderr, "[%zu] >> %s\n", token, query.c_str());
+    if (debug_net > 0) ::rdbxx_debug(token, query.c_str());
     char buf[12];
     memcpy(buf, &token, 8);
     uint32_t size = query.size();

--- a/src/types.cc
+++ b/src/types.cc
@@ -1,6 +1,10 @@
 #include "types.h"
 #include "error.h"
 
+#ifdef __APPLE__
+#include <cstdlib>
+#endif
+
 namespace RethinkDB {
 
 bool Time::parse_utc_offset(const std::string& string, double* offset) {

--- a/src/types.h
+++ b/src/types.h
@@ -4,6 +4,10 @@
 #include <map>
 #include <ctime>
 
+#ifdef __APPLE__
+#include <string>
+#endif
+
 namespace RethinkDB {
 
 class Datum;


### PR DESCRIPTION
Hi!

I started porting the RethinkDB C++ driver before I spotted that there is already an "osx" branch. This is my take on it. Most tests pass, but it reports 16 tests that are failing.

From the reports it looks like results are encapsulated too much. For example:

    Section test_upstream_aggregation: Tests that manipulation data in tables
      FAILURE in ‘R::expr(R::array(R::object("a", 1))).filter(true).limit(1).group("a").run(*conn, R::optargs("group_format", "raw"))’:
        Expected: ‘{"$reql_type$":"GROUPED_DATA","data":[1,[{"a":1}]]}’
         but got: ‘{"$reql_type$":"GROUPED_DATA","data":[[1,[{"a":1}]]]}’

Other times, expressions report null:

    Section test_upstream_control: Tests RQL control flow structures
      FAILURE in ‘R::expr(5).do_(R::row).run(*conn)’:
        Expected: ‘5’
         but got: ‘null’

I am unable to fix these problems myself, but perhaps it helps with the OS X port.

Thanks,

Kim