### PR TITLE
Fix compile errors on OS X

### DIFF
--- a/src/error.h
+++ b/src/error.h
@@ -3,6 +3,7 @@
 #include <cstdarg>
 #include <cstring>
 #include <string>
+#include <cerrno>
 
 namespace RethinkDB {
 

--- a/src/json.cc
+++ b/src/json.cc
@@ -1,4 +1,6 @@
 
+#include <cstdlib>
+#include <xlocale.h>
 #include <cstring>
 #include <locale.h>
 

--- a/src/types.cc
+++ b/src/types.cc
@@ -1,3 +1,5 @@
+#include <cstdlib>
+#include <cmath>
 #include "types.h"
 #include "error.h"
 

--- a/src/types.h
+++ b/src/types.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <map>
 #include <ctime>
+#include <string>
 
 namespace RethinkDB {
 


### PR DESCRIPTION
Hi 

I fix compile errors on OS X with message below.

```
$ make -k
mkdir -p build/gen
python3 reql/gen.py reql/ql2.proto > build/gen/protocol_defs.h
/Users/wingyplus/clang+llvm-3.8.0-x86_64-apple-darwin/bin/clang++ -o build/obj/net.o  -std=c++11 -I'build/gen' -Wall -pthread -fPIC -c src/net.cc -MP -MQ build/obj/net.o -MD -MF build/dep/net.d
In file included from src/net.cc:9:
src/error.h:26:46: error: use of undeclared identifier 'errno'
        return Error("%s: %s", str, strerror(errno));
                                             ^
src/net.cc:273:61: warning: format specifies type 'size_t' (aka 'unsigned long') but the argument has type 'uint64_t'
      (aka 'unsigned long long') [-Wformat]
        if (debug_net > 0) fprintf(stderr, "[%zu] << %s\n", token_got, write_datum(datum).c_str());
                                             ~~~            ^~~~~~~~~
                                             %llu
src/net.cc:319:57: warning: format specifies type 'size_t' (aka 'unsigned long') but the argument has type 'uint64_t'
      (aka 'unsigned long long') [-Wformat]
    if (debug_net > 0) fprintf(stderr, "[%zu] >> %s\n", token, query.c_str());
                                         ~~~            ^~~~~
                                         %llu
2 warnings and 1 error generated.
make: *** [build/obj/net.o] Error 1
/Users/wingyplus/clang+llvm-3.8.0-x86_64-apple-darwin/bin/clang++ -o build/obj/datum.o  -std=c++11 -I'build/gen' -Wall -pthread -fPIC -c src/datum.cc -MP -MQ build/obj/datum.o -MD -MF build/dep/datum.d
In file included from src/datum.cc:1:
In file included from src/datum.h:9:
src/error.h:26:46: error: use of undeclared identifier 'errno'
        return Error("%s: %s", str, strerror(errno));
                                             ^
1 error generated.
make: *** [build/obj/datum.o] Error 1
/Users/wingyplus/clang+llvm-3.8.0-x86_64-apple-darwin/bin/clang++ -o build/obj/json.o  -std=c++11 -I'build/gen' -Wall -pthread -fPIC -c src/json.cc -MP -MQ build/obj/json.o -MD -MF build/dep/json.d
In file included from src/json.cc:5:
In file included from src/json.h:3:
In file included from src/datum.h:9:
src/error.h:26:46: error: use of undeclared identifier 'errno'
        return Error("%s: %s", str, strerror(errno));
                                             ^
src/json.cc:166:1: error: unknown type name 'locale_t'
locale_t locale_c() {
^
src/json.cc:167:12: error: unknown type name 'locale_t'
    static locale_t ret = nullptr;
           ^
src/json.cc:170:25: error: use of undeclared identifier 'LC_ALL_MASK'
        ret = newlocale(LC_ALL_MASK, "C", nullptr);
                        ^
src/json.cc:195:21: error: use of undeclared identifier 'strtod_l'; did you mean 'strtok_r'?
    double number = strtod_l(buf, &end, locale_c());
                    ^~~~~~~~
                    strtok_r
/usr/include/string.h:104:7: note: 'strtok_r' declared here
char    *strtok_r(char *, const char *, char **);
         ^
src/json.cc:195:35: error: cannot initialize a parameter of type 'const char *' with an rvalue of type 'char **'
    double number = strtod_l(buf, &end, locale_c());
                                  ^~~~
/usr/include/string.h:104:36: note: passing argument to parameter here
char    *strtok_r(char *, const char *, char **);
                                      ^
6 errors generated.
make: *** [build/obj/json.o] Error 1
/Users/wingyplus/clang+llvm-3.8.0-x86_64-apple-darwin/bin/clang++ -o build/obj/query.o  -std=c++11 -I'build/gen' -Wall -pthread -fPIC -c src/query.cc -MP -MQ build/obj/query.o -MD -MF build/dep/query.d
In file included from src/query.cc:4:
In file included from src/query.h:3:
In file included from src/datum.h:9:
src/error.h:26:46: error: use of undeclared identifier 'errno'
        return Error("%s: %s", str, strerror(errno));
                                             ^
1 error generated.
make: *** [build/obj/query.o] Error 1
/Users/wingyplus/clang+llvm-3.8.0-x86_64-apple-darwin/bin/clang++ -o build/obj/cursor.o  -std=c++11 -I'build/gen' -Wall -pthread -fPIC -c src/cursor.cc -MP -MQ build/obj/cursor.o -MD -MF build/dep/cursor.d
/Users/wingyplus/clang+llvm-3.8.0-x86_64-apple-darwin/bin/clang++ -o build/obj/types.o  -std=c++11 -I'build/gen' -Wall -pthread -fPIC -c src/types.cc -MP -MQ build/obj/types.o -MD -MF build/dep/types.d
In file included from src/types.cc:1:
src/types.h:25:17: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>,
      std::__1::allocator<char> >'
    std::string data;
                ^
/Users/wingyplus/clang+llvm-3.8.0-x86_64-apple-darwin/bin/../include/c++/v1/iosfwd:193:33: note: template is declared here
    class _LIBCPP_TYPE_VIS_ONLY basic_string;
                                ^
In file included from src/types.cc:2:
src/error.h:26:46: error: use of undeclared identifier 'errno'
        return Error("%s: %s", str, strerror(errno));
                                             ^
src/types.cc:39:24: error: no member named 'abs' in namespace 'std'
    int minutes = std::abs(static_cast<int>(offset / 60)) % 60;
                  ~~~~~^
3 errors generated.
make: *** [build/obj/types.o] Error 1
/Users/wingyplus/clang+llvm-3.8.0-x86_64-apple-darwin/bin/clang++ -o build/obj/utils.o  -std=c++11 -I'build/gen' -Wall -pthread -fPIC -c src/utils.cc -MP -MQ build/obj/utils.o -MD -MF build/dep/utils.d
In file included from src/utils.cc:2:
src/error.h:26:46: error: use of undeclared identifier 'errno'
        return Error("%s: %s", str, strerror(errno));
                                             ^
1 error generated.
make: *** [build/obj/utils.o] Error 1
( echo "// Auto-generated file, built from build/gen/protocol_defs.h src/utils.h src/error.h src/stream.h src/types.h src/datum.h src/json.h src/net.h src/cursor.h src/query.h"; \
	  echo '#pragma once'; \
	  cat build/gen/protocol_defs.h src/utils.h src/error.h src/stream.h src/types.h src/datum.h src/json.h src/net.h src/cursor.h src/query.h | \
	    grep -v '^#pragma once' | \
	    grep -v '^#include "'; \
	) > build/rethinkdb.nodocs.h
mkdir -p build/include
cp build/rethinkdb.nodocs.h build/include/rethinkdb.h
make: Target `default' not remade because of errors.
```