### PR TITLE
Fix #30.

### DIFF
--- a/src/connection_p.h
+++ b/src/connection_p.h
@@ -1,6 +1,7 @@
 #ifndef CONNECTION_P_H
 #define CONNECTION_P_H
 
+#define __STDC_FORMAT_MACROS 1
 #include <inttypes.h>
 
 #include "connection.h"

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -25,15 +25,14 @@ public:
     Cursor& operator=(const Cursor&) = delete;
 
     // Returned by begin() and end()
-    class iterator : public std::iterator<std::forward_iterator_tag, typename RethinkDB::Cursor> {
+    class iterator : public std::iterator<std::input_iterator_tag, typename RethinkDB::Datum> {
     public:
         // Iterator traits - typedefs and types required to be STL compliant
-        typedef std::ptrdiff_t              difference_type;
-        typedef typename RethinkDB::Cursor  value_type;
-        typedef typename RethinkDB::Cursor* pointer;
-        typedef typename RethinkDB::Cursor& reference;
-        typedef size_t                      size_type;
-        std::forward_iterator_tag           iterator_category;
+        typedef typename RethinkDB::Datum  value_type;
+        typedef typename RethinkDB::Datum* pointer;
+        typedef typename RethinkDB::Datum& reference;
+        typedef size_t                     size_type;
+        std::input_iterator_tag            iterator_category;
 
         iterator(Cursor*);
         iterator& operator++ ();

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iterator>
 #include "connection.h"
 
 namespace RethinkDB {
@@ -24,8 +25,16 @@ public:
     Cursor& operator=(const Cursor&) = delete;
 
     // Returned by begin() and end()
-    class iterator {
+    class iterator : public std::iterator<std::forward_iterator_tag, typename RethinkDB::Cursor> {
     public:
+        // Iterator traits - typedefs and types required to be STL compliant
+        typedef std::ptrdiff_t              difference_type;
+        typedef typename RethinkDB::Cursor  value_type;
+        typedef typename RethinkDB::Cursor* pointer;
+        typedef typename RethinkDB::Cursor& reference;
+        typedef size_t                      size_type;
+        std::forward_iterator_tag           iterator_category;
+
         iterator(Cursor*);
         iterator& operator++ ();
         Datum& operator* ();


### PR DESCRIPTION
* C99 specifies that `__STDC_FORMAT_MACROS` must be defined for `PRIu64` to be defined.
* Make RthinkDB::Custor a full fledged std::iterator.